### PR TITLE
Update intensity.R

### DIFF
--- a/R/intensity.R
+++ b/R/intensity.R
@@ -55,7 +55,7 @@ intensity <- function(x, centered = TRUE, centred = centered, scaled = TRUE, nyq
   if (nyquist) {
     if (x.type == 'real') {
       mm  <- ceiling((m+1)/2);
-      INT <- INT[, 1:mm]; } }
+      INT <- INT[, 1:mm, drop=FALSE]; } }
 
   #Convert back to vector if n = 1
   class(INT) <- c('matrix', 'intensity');


### PR DESCRIPTION
This is a minimal fix for the error reported by CRAN. It seems to be caused when INT only has one row, and is then turned into a vector when it is subset down. Apparently the next version of R will be more pedantic about setting a matrix class on a vector lacking `dim` attributes and errors.